### PR TITLE
Flow execution now accepts environment variables

### DIFF
--- a/components/execution.go
+++ b/components/execution.go
@@ -58,6 +58,7 @@ func Execute(
 	buildID string,
 	flowID string,
 	mounts []MountConfiguration,
+	env map[string]string,
 ) (ExecutionMetadata, error) {
 	inverseMounts := map[string]int{}
 	for i, mountConfig := range mounts {
@@ -98,7 +99,17 @@ func Execute(
 
 	containerConfig.Env = make([]string, len(specification.Run.Env))
 	i := 0
+	// finalEnv is formed by merging the env argument to this function over the env specified
+	// in the component specification. This determines the environment variables that get set
+	// for the execution container.
+	finalEnv := map[string]string{}
 	for key, value := range specification.Run.Env {
+		finalEnv[key] = value
+	}
+	for key, value := range env {
+		finalEnv[key] = value
+	}
+	for key, value := range finalEnv {
 		containerConfig.Env[i] = fmt.Sprintf("%s=%s", key, value)
 		i++
 	}

--- a/examples/flows/single-task-twice.json
+++ b/examples/flows/single-task-twice.json
@@ -31,5 +31,13 @@
                 "method": "bind"
             }
         ]
+    },
+    "env": {
+        "first": {
+            "MY_ENV": "hello"
+        },
+        "second": {
+            "MY_ENV": "goodbye"
+        }
     }
 }

--- a/flows/flow.go
+++ b/flows/flow.go
@@ -148,7 +148,7 @@ func Execute(
 	for _, stage := range stages {
 		stepExecutions := map[string]components.ExecutionMetadata{}
 		for _, step := range stage {
-			executionMetadata, err := components.Execute(ctx, db, dockerClient, buildIDs[step], flowID, specification.Mounts[step])
+			executionMetadata, err := components.Execute(ctx, db, dockerClient, buildIDs[step], flowID, specification.Mounts[step], specification.Env[step])
 			if err != nil {
 				return componentExecutions, err
 			}

--- a/flows/specification.go
+++ b/flows/specification.go
@@ -21,6 +21,10 @@ type FlowSpecification struct {
 	Stages [][]string `json:"stages,omitempty"`
 	// Mounts maps each step (by name) to mount configurations for its corresponding component
 	Mounts map[string][]components.MountConfiguration `json:"mounts"`
+	// Env maps each step (by name) to environment variable mappings (key-value mappings of variable
+	// name to variable value) for that step. The environment variable values get materialized
+	// following the same rules as values in a component runtime specification.
+	Env map[string]map[string]string `json:"env,omitempty"`
 }
 
 // MaterializeFlowSpecification takes a raw FlowSpecification struct and returns a materialized one
@@ -75,6 +79,16 @@ func MaterializeFlowSpecification(rawSpecification FlowSpecification) (FlowSpeci
 		materializedMounts[step] = materializedConfigs
 	}
 	materializedSpecification.Mounts = materializedMounts
+
+	materializedEnv := map[string]map[string]string{}
+	for step, envMap := range rawSpecification.Env {
+		materializedEnvMap := map[string]string{}
+		for key, value := range envMap {
+			materializedEnvMap[key] = components.MaterializeEnv(value)
+		}
+		materializedEnv[step] = materializedEnvMap
+	}
+	materializedSpecification.Env = materializedEnv
 
 	return materializedSpecification, nil
 }

--- a/flows/specification_test.go
+++ b/flows/specification_test.go
@@ -240,6 +240,11 @@ func TestMaterializeSpecification(t *testing.T) {
 						},
 					},
 				},
+				Env: map[string]map[string]string{
+					"a": {
+						"key-1": "value-1",
+					},
+				},
 			},
 			expectedSpecification: FlowSpecification{
 				Steps: map[string]string{
@@ -257,6 +262,11 @@ func TestMaterializeSpecification(t *testing.T) {
 							Target: "/input.txt",
 							Method: "bind",
 						},
+					},
+				},
+				Env: map[string]map[string]string{
+					"a": {
+						"key-1": "value-1",
 					},
 				},
 			},

--- a/integration_test.go
+++ b/integration_test.go
@@ -124,7 +124,7 @@ func TestSingleComponent(t *testing.T) {
 		},
 	}
 
-	execution, err := components.Execute(ctx, db, dockerClient, build.ID, "", mounts)
+	execution, err := components.Execute(ctx, db, dockerClient, build.ID, "", mounts, map[string]string{})
 	if err != nil {
 		t.Fatalf("Error executing build (%s): %s", build.ID, err.Error())
 	}
@@ -328,7 +328,6 @@ func TestFlowSingleTaskTwice(t *testing.T) {
 
 	// expectedLine is the value for the MY_ENV variable in the component specification in:
 	// examples/components/single-task/component.json
-	expectedLine := "hello world"
 	scanner := bufio.NewScanner(outputFile)
 	defer outputFile.Close()
 	more := scanner.Scan()
@@ -336,8 +335,8 @@ func TestFlowSingleTaskTwice(t *testing.T) {
 		t.Fatal("Not enough lines in output file")
 	}
 	line := scanner.Text()
-	if line != expectedLine {
-		t.Fatalf("Incorrect value in output file: expected=\"%s\", actual=\"%s\"", expectedLine, line)
+	if line != "hello" {
+		t.Fatalf("Incorrect value in output file: expected=\"%s\", actual=\"%s\"", "hello", line)
 	}
 
 	more = scanner.Scan()
@@ -345,8 +344,8 @@ func TestFlowSingleTaskTwice(t *testing.T) {
 		t.Fatal("Not enough lines in output file")
 	}
 	line = scanner.Text()
-	if line != expectedLine {
-		t.Fatalf("Incorrect value in output file: expected=\"%s\", actual=\"%s\"", expectedLine, line)
+	if line != "goodbye" {
+		t.Fatalf("Incorrect value in output file: expected=\"%s\", actual=\"%s\"", "goodbye", line)
 	}
 
 	terminating := 0

--- a/main.go
+++ b/main.go
@@ -338,7 +338,7 @@ unwanted components from your shnorky state, and build and execute components).
 				log.WithField("error", err).Fatal("Error reading mount configuration")
 			}
 
-			executionMetadata, err := components.Execute(ctx, db, dockerClient, id, "", mounts)
+			executionMetadata, err := components.Execute(ctx, db, dockerClient, id, "", mounts, map[string]string{})
 			if err != nil {
 				log.WithField("error", err).Fatal("Could not execute build")
 			}


### PR DESCRIPTION
Set on a per-step basis. This required the components.Execute method
signature to be changed to accept a map[string]string argument with
environment variable overrides.

The materialization of the flow specification manually runs the
materialization loop (just as in components materialization of run
specification). It is okay for now, but if this logic keeps repeating it
may make sense to add a function exposing the same functionality in the
components package.

The CLI does not accept an environment variable override from the
command line when executing a component. It doesn't really make sense
for it to do so.

Resolves https://github.com/simiotics/shnorky/issues/22